### PR TITLE
add .all method

### DIFF
--- a/src/di-cast.js
+++ b/src/di-cast.js
@@ -403,6 +403,22 @@
             }
 
             /**
+             * Gets an array of all mappings.
+             *
+             * @method all
+             * @for DiCast
+             * @return {Array} An array of mapping objects.
+             */
+            this.all = function() {
+
+                if(!parent) {
+                    return [mappings];
+                }
+
+                return parent.all().concat([mappings]);
+            };
+
+            /**
              * Initialises a mapping key and returns the different methods for creating a mapping.
              *
              * @method map


### PR DESCRIPTION
Add a method to retrieve all mappings including parents mappings.
Useful for debugging.
